### PR TITLE
Add shebang to use bash

### DIFF
--- a/run_compilation.sh
+++ b/run_compilation.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 ### Parameters
 go_get_repository_uri="github.com/dontsetse/systemd-docker"
 


### PR DESCRIPTION
If you start the script not in a bash shell, you may get an error.

zsh for example rises the following error:

```
./run_compilation.sh: 9: ./run_compilation.sh: Bad substitution
```